### PR TITLE
feat: --match-file-name command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "solstat"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "colour",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solstat"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 description = "A Solidity static analyzer to identify contract vulnerabilities and gas efficiencies."

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ A Solidity static analyzer to identify contract vulnerabilities and gas efficien
 # Table of Contents
 - [Installation](#installation)
 - [Usage](#usage)
-- [Identified Issues](#identified-optimizations-vulnerabilities-and-qa)
-  - [⚡Optimizations](#⚡identified-gas-optimizations)
-  - [🪲Vulnerabilities](#🪲-identified-vulnerabilities)
-  - [👍Quality Assurance](#👍-identified-qa)
+- [Identified Issues](https://github.com/0xKitsune/solstat/tree/main/docs)
+  - [⚡Optimizations](https://github.com/0xKitsune/solstat/blob/main/docs/indentified-optimizations.md)
+  - [🪲Vulnerabilities](https://github.com/0xKitsune/solstat/blob/main/docs/indentified-vulnerabilities.md)
+  - [👍Quality Assurance](https://github.com/0xKitsune/solstat/blob/main/docs/identified-quality-assurance.md)
 - [Example Reports](https://github.com/0xKitsune/solstat-reports)
 - [Contributing](#contributing)
 
@@ -60,6 +60,6 @@ Options:
 
 &nbsp;
 # Contributing
-First off, thanks for taking the time to contribute! Contributions are **welcomed** and **greatly appreciated**.
+First off, thanks for taking the time to contribute! Contributions are welcomed and greatly appreciated.
 
 If you are interested in contributing, please check out [Contributing.md](https://github.com/0xKitsune/solstat/blob/main/docs/Contributing.md).

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Usage: solstat [OPTIONS]
 
 Options:
   -p, --path <PATH>  Path to the directory containing the files solstat will analyze. The default directory is `./contracts`
+  -m, --match-file-name <MATCH_FILE_NAME> Name of the file Solstat will analyze. The default is all files within the provided directory.
   -t, --toml <TOML>  Path to the toml file containing the solstat configuration when not using the default settings.
   -h, --help         Print help information
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,6 @@ fn main() {
     let vulnerabilities = vulnerabilities::analyze_dir(&opts.path, opts.vulnerabilities);
     let optimizations = optimizations::analyze_dir(&opts.path, opts.optimizations);
     let qa = qa::analyze_dir(&opts.path, opts.qa);
-
-    generate_report(vulnerabilities, optimizations, qa);
+    
+    generate_report(vulnerabilities, optimizations, qa, opts.match_file_name);
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -25,6 +25,13 @@ pub struct Args {
     #[clap(
         short,
         long,
+        help = "Name of the file Solstat will analyze. The default is all files within the provided directory."
+    )]
+    pub match_file_name: Option<String>,
+
+    #[clap(
+        short,
+        long,
         help = "Path to the toml file containing the Solstat configuration when not using the default settings."
     )]
     pub toml: Option<String>,
@@ -32,6 +39,7 @@ pub struct Args {
 
 pub struct Opts {
     pub path: String,
+    pub match_file_name: String,
     pub optimizations: Vec<Optimization>,
     pub vulnerabilities: Vec<Vulnerability>,
     pub qa: Vec<QualityAssurance>,
@@ -40,6 +48,7 @@ pub struct Opts {
 #[derive(serde::Deserialize, Debug)]
 pub struct SolstatToml {
     pub path: String,
+    pub match_file_name: String,
     pub optimizations: Vec<String>,
     pub vulnerabilities: Vec<String>,
     pub qa: Vec<String>,
@@ -102,8 +111,15 @@ To fix this, either add a `./contracts` directory or provide `--path <path_to_co
             String::from("./contracts")
         };
 
+        let match_file_name = if args.match_file_name.is_some() {
+            args.match_file_name.unwrap()
+        } else {
+            String::from("")
+        };
+
         Opts {
             path,
+            match_file_name,
             optimizations,
             vulnerabilities,
             qa,

--- a/src/report/generation.rs
+++ b/src/report/generation.rs
@@ -17,21 +17,22 @@ pub fn generate_report(
     vulnerabilities: HashMap<Vulnerability, Vec<(String, BTreeSet<LineNumber>)>>,
     optimizations: HashMap<Optimization, Vec<(String, BTreeSet<LineNumber>)>>,
     qa: HashMap<QualityAssurance, Vec<(String, BTreeSet<LineNumber>)>>,
+    match_file_name: String,
 ) {
     let mut solstat_report = String::from("");
 
     if vulnerabilities.len() > 0 {
-        solstat_report.push_str(&generate_vulnerability_report(vulnerabilities));
+        solstat_report.push_str(&generate_vulnerability_report(vulnerabilities, match_file_name.to_string()));
         solstat_report.push_str("\n\n");
     }
 
     if optimizations.len() > 0 {
-        solstat_report.push_str(&generate_optimization_report(optimizations));
+        solstat_report.push_str(&generate_optimization_report(optimizations, match_file_name.to_string()));
         solstat_report.push_str("\n\n");
     }
 
     if qa.len() > 0 {
-        solstat_report.push_str(&generate_qa_report(qa));
+        solstat_report.push_str(&generate_qa_report(qa, match_file_name.to_string()));
         solstat_report.push_str("\n\n");
     }
 

--- a/src/report/optimization_report.rs
+++ b/src/report/optimization_report.rs
@@ -14,6 +14,7 @@ use crate::report::report_sections::optimizations::{
 
 pub fn generate_optimization_report(
     optimizations: HashMap<Optimization, Vec<(String, BTreeSet<LineNumber>)>>,
+    match_file_name: String,
 ) -> String {
     let mut optimization_report = String::from("");
 
@@ -30,12 +31,23 @@ pub fn generate_optimization_report(
 
             for (file_name, mut lines) in matches {
                 for line in lines {
-                    //- file_name:line_number\n
-                    matches_section
-                        .push_str(&(String::from("- ") + &file_name + ":" + &line.to_string()));
-                    matches_section.push_str("\n");
+                    if match_file_name != String::from("") {
+                        if file_name == match_file_name {
+                            //- file_name:line_number\n
+                            matches_section
+                                .push_str(&(String::from("- ") + &file_name + ":" + &line.to_string()));
+                            matches_section.push_str("\n");
 
-                    total_optimizations_found += 1;
+                            total_optimizations_found += 1;
+                        }
+                    } else {
+                        //- file_name:line_number\n
+                        matches_section
+                            .push_str(&(String::from("- ") + &file_name + ":" + &line.to_string()));
+                        matches_section.push_str("\n");
+
+                        total_optimizations_found += 1;
+                    }
                 }
             }
 

--- a/src/report/optimization_report.rs
+++ b/src/report/optimization_report.rs
@@ -25,7 +25,7 @@ pub fn generate_optimization_report(
             let optimization_target = optimization.0;
             let matches = optimization.1;
 
-            let report_section = get_optimization_report_section(optimization_target);
+            let mut report_section = get_optimization_report_section(optimization_target);
 
             let mut matches_section = String::from("### Lines\n");
 
@@ -49,6 +49,10 @@ pub fn generate_optimization_report(
                         total_optimizations_found += 1;
                     }
                 }
+            }
+
+            if total_optimizations_found == 0 {
+                report_section = String::from("");
             }
 
             matches_section.push_str("\n\n");

--- a/src/report/qa_report.rs
+++ b/src/report/qa_report.rs
@@ -7,6 +7,7 @@ use crate::report::report_sections::qa::overview;
 
 pub fn generate_qa_report(
     qa_items: HashMap<QualityAssurance, Vec<(String, BTreeSet<LineNumber>)>>,
+    match_file_name: String,
 ) -> String {
     let mut qa_report = String::from("");
 
@@ -26,10 +27,17 @@ pub fn generate_qa_report(
 
             for (file_name, mut lines) in matches {
                 for line in lines {
-                    //- file_name:line_number\n
-                    matches_section
-                        .push_str(&(String::from("- ") + &file_name + ":" + &line.to_string()));
-                    matches_section.push_str("\n");
+                    if match_file_name != String::from("") {
+                        if file_name == match_file_name {
+                            //- file_name:line_number\n
+                            matches_section.push_str(&(String::from("- ") + &file_name + ":" + &line.to_string()));
+                            matches_section.push_str("\n");
+                        }
+                    } else {
+                        //- file_name:line_number\n
+                        matches_section.push_str(&(String::from("- ") + &file_name + ":" + &line.to_string()));
+                        matches_section.push_str("\n");
+                    }
                 }
             }
 

--- a/src/report/vulnerability_report.rs
+++ b/src/report/vulnerability_report.rs
@@ -7,6 +7,7 @@ use crate::report::report_sections::vulnerabilities::overview;
 
 pub fn generate_vulnerability_report(
     vulnerabilities: HashMap<Vulnerability, Vec<(String, BTreeSet<LineNumber>)>>,
+    match_file_name: String,
 ) -> String {
     let mut vulnerability_report = String::from("");
 
@@ -32,10 +33,19 @@ pub fn generate_vulnerability_report(
 
             for (file_name, mut lines) in matches {
                 for line in lines {
-                    //- file_name:line_number\n
-                    matches_section
-                        .push_str(&(String::from("- ") + &file_name + ":" + &line.to_string()));
-                    matches_section.push_str("\n");
+                    if match_file_name != String::from("") {
+                        if file_name == match_file_name {
+                            //- file_name:line_number\n
+                            matches_section
+                                .push_str(&(String::from("- ") + &file_name + ":" + &line.to_string()));
+                            matches_section.push_str("\n");
+                        }
+                    } else {
+                        //- file_name:line_number\n
+                        matches_section
+                            .push_str(&(String::from("- ") + &file_name + ":" + &line.to_string()));
+                        matches_section.push_str("\n");
+                    }
                 }
             }
 


### PR DESCRIPTION
Introduces `--match-file-name` command which allows users to generate a report for a specific contract within path.

### Usage
```js
solstat --match-file-name "Contract.sol"
```