### PR TITLE
Immutable variable patch

### DIFF
--- a/src/analyzer/optimizations/mod.rs
+++ b/src/analyzer/optimizations/mod.rs
@@ -174,18 +174,20 @@ pub fn analyze_dir(
                 .expect("Could not convert file name from OsStr to &str")
                 .to_string();
 
-            let file_contents = fs::read_to_string(&file_path).expect("Unable to read file");
+            if !file_name.to_lowercase().contains(".t.sol") {
+                let file_contents = fs::read_to_string(&file_path).expect("Unable to read file");
 
-            //For each active optimization
-            for optimization in &optimizations {
-                let line_numbers = analyze_for_optimization(&file_contents, i, *optimization);
+                //For each active optimization
+                for optimization in &optimizations {
+                    let line_numbers = analyze_for_optimization(&file_contents, i, *optimization);
 
-                if line_numbers.len() > 0 {
-                    let file_optimizations = optimization_locations
-                        .entry(optimization.clone())
-                        .or_insert(vec![]);
+                    if line_numbers.len() > 0 {
+                        let file_optimizations = optimization_locations
+                            .entry(optimization.clone())
+                            .or_insert(vec![]);
 
-                    file_optimizations.push((file_name.clone(), line_numbers));
+                        file_optimizations.push((file_name.clone(), line_numbers));
+                    }
                 }
             }
         }

--- a/src/analyzer/optimizations/mod.rs
+++ b/src/analyzer/optimizations/mod.rs
@@ -174,7 +174,7 @@ pub fn analyze_dir(
                 .expect("Could not convert file name from OsStr to &str")
                 .to_string();
 
-            if !file_name.to_lowercase().contains(".t.sol") {
+            if file_name.ends_with(".sol") && !file_name.to_lowercase().contains(".t.sol") {
                 let file_contents = fs::read_to_string(&file_path).expect("Unable to read file");
 
                 //For each active optimization

--- a/src/analyzer/qa/mod.rs
+++ b/src/analyzer/qa/mod.rs
@@ -61,16 +61,19 @@ pub fn analyze_dir(
                 .expect("Could not convert file name from OsStr to &str")
                 .to_string();
 
-            let file_contents = fs::read_to_string(&file_path).expect("Unable to read file");
+            if !file_name.to_lowercase().contains(".t.sol") {
+                let file_contents = fs::read_to_string(&file_path).expect("Unable to read file");
 
-            //For each active optimization
-            for target in &qa {
-                let line_numbers = analyze_for_qa(&file_contents, i, *target);
+                //For each active optimization
+                for target in &qa {
+                    let line_numbers = analyze_for_qa(&file_contents, i, *target);
 
-                if line_numbers.len() > 0 {
-                    let file_optimizations = qa_locations.entry(target.clone()).or_insert(vec![]);
+                    if line_numbers.len() > 0 {
+                        let file_optimizations =
+                            qa_locations.entry(target.clone()).or_insert(vec![]);
 
-                    file_optimizations.push((file_name.clone(), line_numbers));
+                        file_optimizations.push((file_name.clone(), line_numbers));
+                    }
                 }
             }
         }

--- a/src/analyzer/qa/mod.rs
+++ b/src/analyzer/qa/mod.rs
@@ -61,7 +61,7 @@ pub fn analyze_dir(
                 .expect("Could not convert file name from OsStr to &str")
                 .to_string();
 
-            if !file_name.to_lowercase().contains(".t.sol") {
+            if file_name.ends_with(".sol") && !file_name.to_lowercase().contains(".t.sol") {
                 let file_contents = fs::read_to_string(&file_path).expect("Unable to read file");
 
                 //For each active optimization

--- a/src/analyzer/vulnerabilities/mod.rs
+++ b/src/analyzer/vulnerabilities/mod.rs
@@ -69,18 +69,20 @@ pub fn analyze_dir(
                 .expect("Could not convert file name from OsStr to &str")
                 .to_string();
 
-            let file_contents = fs::read_to_string(&file_path).expect("Unable to read file");
+            if !file_name.to_lowercase().contains(".t.sol") {
+                let file_contents = fs::read_to_string(&file_path).expect("Unable to read file");
 
-            //For each active optimization
-            for vulnerability in &vulnerabilities {
-                let line_numbers = analyze_for_vulnerability(&file_contents, i, *vulnerability);
+                //For each active optimization
+                for vulnerability in &vulnerabilities {
+                    let line_numbers = analyze_for_vulnerability(&file_contents, i, *vulnerability);
 
-                if line_numbers.len() > 0 {
-                    let file_optimizations = vulnerability_locations
-                        .entry(vulnerability.clone())
-                        .or_insert(vec![]);
+                    if line_numbers.len() > 0 {
+                        let file_optimizations = vulnerability_locations
+                            .entry(vulnerability.clone())
+                            .or_insert(vec![]);
 
-                    file_optimizations.push((file_name.clone(), line_numbers));
+                        file_optimizations.push((file_name.clone(), line_numbers));
+                    }
                 }
             }
         }

--- a/src/analyzer/vulnerabilities/mod.rs
+++ b/src/analyzer/vulnerabilities/mod.rs
@@ -69,7 +69,7 @@ pub fn analyze_dir(
                 .expect("Could not convert file name from OsStr to &str")
                 .to_string();
 
-            if !file_name.to_lowercase().contains(".t.sol") {
+            if file_name.ends_with(".sol") && !file_name.to_lowercase().contains(".t.sol") {
                 let file_contents = fs::read_to_string(&file_path).expect("Unable to read file");
 
                 //For each active optimization


### PR DESCRIPTION
PR addressing issue #35

Patched issue when unwrapping expression during immutable variable optimization. The issue was that the optimization was extracting all `Target::FunctionDefinition` and unwrapping when converting the Target into an expression. This was an issue because FunctionDefinition can also be a `SourceUnitPart`. Handling was added for both cases. 

Additional logic was also added to ignore test files that contain ".t.sol" in the file name. Also, logic was added to only analyze files that end with `.sol` (with exception for `.t.sol`