### PR TITLE
chore: update cargo lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "solstat"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "colour",


### PR DESCRIPTION
Solstat has been bumped to version 0.5.0 in the `cargo.toml`. Shouldn't the `cargo.lock` get updated as well?

Not 100% sure on this one, so please correct me if I'm wrong.
