### PR TITLE
feat: add unprotected selfdestruct vulnerability

### DIFF
--- a/src/analyzer/vulnerabilities/mod.rs
+++ b/src/analyzer/vulnerabilities/mod.rs
@@ -16,6 +16,7 @@ use super::utils::{self, LineNumber};
 
 use self::{
     floating_pragma::floating_pragma_vulnerability,
+    unprotected_selfdestruct::unprotected_selfdestruct_vulnerability,
     unsafe_erc20_operation::unsafe_erc20_operation_vulnerability,
 };
 
@@ -24,12 +25,14 @@ use self::{
 pub enum Vulnerability {
     FloatingPragma,
     UnsafeERC20Operation,
+    UnprotectedSelfdestruct,
 }
 
 pub fn get_all_vulnerabilities() -> Vec<Vulnerability> {
     vec![
         Vulnerability::FloatingPragma,
         Vulnerability::UnsafeERC20Operation,
+        Vulnerability::UnprotectedSelfdestruct,
     ]
 }
 
@@ -37,6 +40,7 @@ pub fn str_to_vulnerability(vuln: &str) -> Vulnerability {
     match vuln.to_lowercase().as_str() {
         "floating_pragma" => Vulnerability::FloatingPragma,
         "unsafe_erc20_operation" => Vulnerability::UnsafeERC20Operation,
+        "unprotected_selfdestruct" => Vulnerability::UnprotectedSelfdestruct,
 
         other => {
             panic!("Unrecgonized vulnerability: {}", other)
@@ -114,6 +118,9 @@ pub fn analyze_for_vulnerability(
     let locations = match vulnerability {
         Vulnerability::FloatingPragma => floating_pragma_vulnerability(source_unit),
         Vulnerability::UnsafeERC20Operation => unsafe_erc20_operation_vulnerability(source_unit),
+        Vulnerability::UnprotectedSelfdestruct => {
+            unprotected_selfdestruct_vulnerability(source_unit)
+        }
     };
 
     for loc in locations {

--- a/src/analyzer/vulnerabilities/mod.rs
+++ b/src/analyzer/vulnerabilities/mod.rs
@@ -1,4 +1,5 @@
 pub mod template;
+pub mod unprotected_selfdestruct;
 pub mod unsafe_erc20_operation;
 
 use std::{

--- a/src/analyzer/vulnerabilities/unprotected_selfdestruct.rs
+++ b/src/analyzer/vulnerabilities/unprotected_selfdestruct.rs
@@ -7,7 +7,7 @@ use solang_parser::pt::{
 
 use crate::analyzer::ast::{self, Target};
 
-pub fn _unprotected_selfdestruct_vulnerability(source_unit: SourceUnit) -> HashSet<Loc> {
+pub fn unprotected_selfdestruct_vulnerability(source_unit: SourceUnit) -> HashSet<Loc> {
     //Create a new hashset that stores the location of each vulnerability target identified
     let mut vulnerability_locations: HashSet<Loc> = HashSet::new();
 
@@ -238,6 +238,6 @@ fn test_unprotected_selfdestruct_vulnerability() {
 
     let source_unit = solang_parser::parse(file_contents, 0).unwrap().0;
 
-    let vulnerability_locations = _unprotected_selfdestruct_vulnerability(source_unit);
+    let vulnerability_locations = unprotected_selfdestruct_vulnerability(source_unit);
     assert_eq!(vulnerability_locations.len(), 2)
 }

--- a/src/analyzer/vulnerabilities/unprotected_selfdestruct.rs
+++ b/src/analyzer/vulnerabilities/unprotected_selfdestruct.rs
@@ -170,7 +170,7 @@ fn _contains_msg_sender_conditions(function_definition: &Box<FunctionDefinition>
                         if let Expression::MemberAccess(_, box_expression, identifier) =
                             *box_expression
                         {
-                            //If the member access identifier is "msg.sender" the function is considered protected
+                            //If the member access identifier is "msg.sender"
                             let Identifier { name: right, .. } = identifier;
                             if let Expression::Variable(Identifier { name: left, .. }) =
                                 *box_expression
@@ -184,7 +184,7 @@ fn _contains_msg_sender_conditions(function_definition: &Box<FunctionDefinition>
 
                     //Match for `function(msg.sender)`
                     Expression::MemberAccess(_, box_expression, identifier) => {
-                        //If the member access identifier is "msg.sender" the function is considered protected
+                        //If the member access identifier is "msg.sender"
                         let Identifier { name: right, .. } = identifier;
                         if let Expression::Variable(Identifier { name: left, .. }) = *box_expression
                         {

--- a/src/analyzer/vulnerabilities/unprotected_selfdestruct.rs
+++ b/src/analyzer/vulnerabilities/unprotected_selfdestruct.rs
@@ -1,0 +1,224 @@
+use std::collections::HashSet;
+
+use solang_parser::pt::{
+    Base, ContractPart, Expression, FunctionAttribute, FunctionDefinition, FunctionTy, Identifier,
+    IdentifierPath, Loc, SourceUnit, Visibility,
+};
+
+use crate::analyzer::ast::{self, Target};
+
+pub fn _unprotected_selfdestruct_vulnerability(source_unit: SourceUnit) -> HashSet<Loc> {
+    //Create a new hashset that stores the location of each vulnerability target identified
+    let mut vulnerability_locations: HashSet<Loc> = HashSet::new();
+
+    // what this vulnerability check does:
+    // 1. extract all function definitions
+    // 2. remove constructors
+    // 3. take only public or external functions
+    // 4. check if there are any "suicide" or "selfdestruct" calls inside
+    // 5. implement an "is_protected" helper that checks for modifiers and conditions
+    //   5.1. check if there are any modifiers which contain "only" in the name
+    //        (suggesting that some protection has been devised, and assuming it is safe)
+    //   5.2. if there aren't, check for conditions:
+    //      5.2.1. either where msg.sender is used as argument (e.g. `check(msg.sender)`)
+    //      5.2.2. or where msg.sender is used in a condition (e.g. `msg.sender == owner`)
+    // 6. add loc of the nodes that pass all the criteria to the vulnerability_locations
+
+    let contract_definition_nodes =
+        ast::extract_target_from_node(Target::ContractDefinition, source_unit.into());
+
+    for contract_definition_node in contract_definition_nodes {
+        let target_nodes = ast::extract_target_from_node(
+            Target::FunctionDefinition,
+            contract_definition_node.into(),
+        );
+
+        for node in target_nodes {
+            //We can use unwrap because Target::FunctionDefinition is a contract_part
+            let contract_part = node.contract_part().unwrap();
+
+            if let ContractPart::FunctionDefinition(box_function_definition) = contract_part {
+                //If there is function body
+                if box_function_definition.body.is_some() {
+                    //Skip the constructor as it cannot be affected
+                    if box_function_definition.ty == FunctionTy::Constructor {
+                        continue;
+                    }
+
+                    if box_function_definition.attributes.len() > 0 {
+                        //Skip functions that are not public or external as they cannot be affected
+                        if !_is_public_or_external(&box_function_definition) {
+                            continue;
+                        }
+
+                        let function_body_nodes = ast::extract_target_from_node(
+                            Target::FunctionCall,
+                            box_function_definition.body.clone().unwrap().into(),
+                        );
+
+                        for function_body_node in function_body_nodes {
+                            //We can use unwrap because Target::FunctionCall is an expression
+                            let expression = function_body_node.expression().unwrap();
+
+                            if let Expression::FunctionCall(loc, box_identifier, ..) = expression {
+                                //If the function is a selfdestruct call
+                                if _is_selfdestruct(box_identifier) {
+                                    //Check if the function is protected. If it isn't, add the loc to the vulnerabilities
+                                    if !_is_protected(&box_function_definition) {
+                                        vulnerability_locations.insert(loc);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    //Return the identified vulnerability locations
+    vulnerability_locations
+}
+
+//Return true if the visibility of a given function is public or external. Return false otherwise.
+fn _is_public_or_external(function_definition: &Box<FunctionDefinition>) -> bool {
+    let mut public_or_external = false;
+    if function_definition.attributes.len() > 0 {
+        for attr in &function_definition.attributes {
+            match attr {
+                FunctionAttribute::Visibility(visibility) => match visibility {
+                    Visibility::External(_) => {
+                        public_or_external = true;
+                    }
+                    Visibility::Public(_) => {
+                        public_or_external = true;
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+    }
+
+    public_or_external
+}
+
+fn _is_selfdestruct(box_identifier: Box<Expression>) -> bool {
+    let mut is_selfdestruct = false;
+    if let Expression::Variable(identifier) = *box_identifier {
+        //If the function name is "selfdestruct" or "suicide"
+        if identifier.name == "selfdestruct" || identifier.name == "suicide" {
+            is_selfdestruct = true;
+        }
+    }
+
+    is_selfdestruct
+}
+
+//Check if a function is protected using modifiers or conditions. Return false otherwise.
+//This check is not exhaustive and can be improved. For example, it does not check if the modifier
+//is implemented correctly. It only checks if the modifier name contains the word "only".
+//Otherwise, only checks if there are any conditions on "msg.sender" applied.
+fn _is_protected(function_definition: &Box<FunctionDefinition>) -> bool {
+    if function_definition.attributes.len() > 0 {
+        for attr in &function_definition.attributes {
+            match attr {
+                //If the function has a modifier
+                FunctionAttribute::BaseOrModifier(_, base) => {
+                    let Base { name, .. } = base;
+                    let IdentifierPath { identifiers, .. } = name;
+
+                    for identifier in identifiers {
+                        //If the modifier name contains "only"
+                        if identifier.name.contains("only") {
+                            return true;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    //If there are no modifiers, check if there are any conditions applied on msg.sender
+    if function_definition.body.is_some() {
+        let function_body_nodes = ast::extract_target_from_node(
+            Target::FunctionCall,
+            function_definition.body.clone().unwrap().into(),
+        );
+
+        for node in function_body_nodes {
+            //We can use unwrap because Target::MemberAccess is an expression
+            let expression = node.expression().unwrap();
+
+            if let Expression::FunctionCall(_, box_identifier, vec_expression) = expression {
+                if _is_selfdestruct(box_identifier) {
+                    continue;
+                }
+
+                for expression in vec_expression {
+                    match expression {
+                        Expression::Equal(_, box_expression, _) => {
+                            if let Expression::MemberAccess(_, box_expression, identifier) =
+                                *box_expression
+                            {
+                                //If the member access identifier is "msg.sender" the function is considered protected
+                                let Identifier { name: right, .. } = identifier;
+                                if let Expression::Variable(Identifier { name: left, .. }) =
+                                    *box_expression
+                                {
+                                    if left == "msg" && right == "sender" {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+
+                        _ => {}
+                    };
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+#[test]
+fn test_unprotected_selfdestruct_vulnerability() {
+    let file_contents = r#"
+    
+    contract Contract0 {
+        // unsafe
+        function unprotectedKill() public {
+            selfdestruct(msg.sender);
+        }
+
+        // unsafe
+        function unprotectedKill2() external {
+            suicide(owner);
+        }
+
+        // safe
+        function protectedKill() public {
+            require(msg.sender == owner);
+            selfdestruct(msg.sender);
+        }
+
+        // safe
+        function protectedKill2() public onlyOwner {
+            selfdestruct(msg.sender);
+        }
+
+        // safe
+        function internalKill() internal {
+            selfdestruct(msg.sender);
+        }
+    }
+    "#;
+
+    let source_unit = solang_parser::parse(file_contents, 0).unwrap().0;
+
+    let vulnerability_locations = _unprotected_selfdestruct_vulnerability(source_unit);
+    assert_eq!(vulnerability_locations.len(), 2)
+}

--- a/src/report/report_sections/vulnerabilities/mod.rs
+++ b/src/report/report_sections/vulnerabilities/mod.rs
@@ -1,3 +1,4 @@
 pub mod floating_pragma;
 pub mod overview;
+pub mod unprotected_selfdestruct;
 pub mod unsafe_erc20_operation;

--- a/src/report/report_sections/vulnerabilities/unprotected_selfdestruct.rs
+++ b/src/report/report_sections/vulnerabilities/unprotected_selfdestruct.rs
@@ -1,0 +1,42 @@
+pub fn report_section_content() -> String {
+    String::from(
+        r##"
+Unprotected call to a function executing `selfdestruct` or `suicide`.
+
+#### Exploit scenario
+```js
+contract Suicidal {
+  function kill() public {
+      selfdestruct(msg.sender);
+  }
+}
+```
+Anyone can call kill() and destroy the contract.
+
+#### Recommendations
+Protect access to all affected functions. Consider one of the following solutions:
+1. Restrict the visibility of the function to `internal` or `private`. 
+2. If the function must be public, either:
+  2.1. Add a modifier to allow only shortlisted EOAs to call this function (such as `onlyOwner`).
+  2.2. Add a check on the `msg.sender` directly inside the affected function.
+
+```js
+  // restrict visibility to internal or private
+  function kill() internal {
+    selfdestruct(msg.sender);
+  }
+
+  // add a modifier to allow only shortlisted EOAs to call this function
+  function kill() public onlyOwner {
+    selfdestruct(msg.sender);
+  }
+
+  // add a check on the msg.sender directly inside the affected function
+  function kill() public {
+    require(msg.sender == owner);
+    selfdestruct(msg.sender);
+  }
+```
+"##,
+    )
+}

--- a/src/report/vulnerability_report.rs
+++ b/src/report/vulnerability_report.rs
@@ -5,7 +5,7 @@ use crate::analyzer::utils::LineNumber;
 use crate::analyzer::vulnerabilities::Vulnerability;
 
 use crate::report::report_sections::vulnerabilities::{
-    floating_pragma, overview, unsafe_erc20_operation,
+    floating_pragma, overview, unprotected_selfdestruct, unsafe_erc20_operation,
 };
 
 pub fn generate_vulnerability_report(
@@ -96,6 +96,10 @@ pub fn get_vulnerability_report_section(
         Vulnerability::UnsafeERC20Operation => (
             unsafe_erc20_operation::report_section_content(),
             VulnerabilitySeverity::Low,
+        ),
+        Vulnerability::UnprotectedSelfdestruct => (
+            unprotected_selfdestruct::report_section_content(),
+            VulnerabilitySeverity::High,
         ),
     }
 }


### PR DESCRIPTION
Closes #62 

---

Hi! This is my first contribution to Open Source ever 😊

Here's the basic gist of the vulnerability implementation:

Iterate over all function definitions:
  - Skip constructors and internal or private functions (as they are not vulnerable)
  - Analyze the body of the remaining functions:
    - check if they contain any selfdestruct calls
    - if they do, check if the function is protected (with modifiers or conditions)

For the last step, I am checking the following criteria to decide if a function is protected or not:
- If it contains a modifier that contains "only" in its name, the function is considered protected
- If its body contains any function calls that take `msg.sender` as argument, the function is considered protected
- If its body contains any function calls that evaluate an equality or inequality expression on `msg.sender`, the function is considered protected.

This check is not exhaustive. For instance, it doesn't check if the modifier applied is implemented correctly. I made sure to specify this in a comment at line 54 of the vulnerability file.

I had to implement a few helper functions inside the vulnerability file, because indentation was getting too crazy and I believe it is more readable like this. Please do let me know if you wish to remove them and keep everything in the top-level vulnerability function instead. 

At lines 173-181 and 187-194 in the vulnerability file, there is some repeated code. I am aware of this fact, and were considering adding another helper function to alleviate it, but I decided not to in order to keep the helpers more specialized and clear in their functionality.

Please let me know if I missed anything!