### PR TITLE
Added: SolHint[private-vars-leading-underscore] rule | #42

### DIFF
--- a/src/analyzer/qa/mod.rs
+++ b/src/analyzer/qa/mod.rs
@@ -1,4 +1,6 @@
 pub mod constructor_order;
+pub mod private_func_leading_underscore;
+pub mod private_vars_leading_underscore;
 pub mod template;
 
 use std::{
@@ -8,22 +10,34 @@ use std::{
     str::FromStr,
 };
 
-use self::constructor_order::constructor_order_qa;
+use self::{
+    constructor_order::constructor_order_qa,
+    private_func_leading_underscore::private_func_leading_underscore,
+    private_vars_leading_underscore::private_vars_leading_underscore,
+};
 
 use super::utils::{self, LineNumber};
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum QualityAssurance {
     ConstructorOrder,
+    PrivateVarsLeadingUnderscore,
+    PrivateFuncLeadingUnderscore,
 }
 
 pub fn get_all_qa() -> Vec<QualityAssurance> {
-    vec![QualityAssurance::ConstructorOrder]
+    vec![
+        QualityAssurance::ConstructorOrder,
+        QualityAssurance::PrivateVarsLeadingUnderscore,
+        QualityAssurance::PrivateFuncLeadingUnderscore,
+    ]
 }
 
 pub fn str_to_qa(qa: &str) -> QualityAssurance {
     match qa.to_lowercase().as_str() {
         "constructor_order" => QualityAssurance::ConstructorOrder,
+        "private_vars_leading_underscore" => QualityAssurance::PrivateVarsLeadingUnderscore,
+        "private_func_leading_underscore" => QualityAssurance::PrivateFuncLeadingUnderscore,
         other => {
             panic!("Unrecgonized qa: {}", other)
         }
@@ -98,6 +112,12 @@ pub fn analyze_for_qa(
 
     let locations = match qa {
         QualityAssurance::ConstructorOrder => constructor_order_qa(source_unit),
+        QualityAssurance::PrivateVarsLeadingUnderscore => {
+            private_vars_leading_underscore(source_unit)
+        }
+        QualityAssurance::PrivateFuncLeadingUnderscore => {
+            private_func_leading_underscore(source_unit)
+        }
         _ => panic!("Location dont recognized"),
     };
 

--- a/src/analyzer/qa/private_func_leading_underscore.rs
+++ b/src/analyzer/qa/private_func_leading_underscore.rs
@@ -1,0 +1,79 @@
+use std::collections::HashSet;
+
+use solang_parser::pt::{self, FunctionTy, Loc};
+use solang_parser::{self, pt::SourceUnit};
+
+use crate::analyzer::ast::{self, Target};
+
+pub fn private_func_leading_underscore(source_unit: SourceUnit) -> HashSet<Loc> {
+    //Create a new hashset that stores the location of each qa target identified
+    let mut qa_locations: HashSet<Loc> = HashSet::new();
+    //Extract the target nodes from the source_unit
+    let target_nodes =
+        ast::extract_target_from_node(Target::FunctionDefinition, source_unit.into());
+
+    for node in target_nodes {
+        let contract_part = node.contract_part().unwrap();
+
+        if let pt::ContractPart::FunctionDefinition(box_fn_definition) = contract_part {
+            if FunctionTy::Function != box_fn_definition.ty {
+                continue;
+            }
+
+            for attr in box_fn_definition.attributes {
+                if let pt::FunctionAttribute::Visibility(v) = attr {
+                    let fn_def_data = box_fn_definition.name.clone();
+                    if fn_def_data.is_some() {
+                        let fn_data = fn_def_data.unwrap();
+                        match v {
+                            pt::Visibility::Public(_) | pt::Visibility::External(_) => {
+                                if fn_data.name.starts_with('_') {
+                                    qa_locations.insert(fn_data.loc);
+                                }
+                            }
+                            // Private or Internal functions
+                            _ => {
+                                if !fn_data.name.starts_with('_') {
+                                    qa_locations.insert(fn_data.loc);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    //Return the identified qa locations
+    qa_locations
+}
+
+#[test]
+fn test_private_func_leading_underscore() {
+    let file_contents = r#"
+    
+    contract Contract0 {
+        
+        function msgSender() internal view returns(address) {
+            return msg.sender;
+        }
+
+        function _msgSender() internal view returns(address) {
+            return msg.sender;
+        }
+
+        function _msgData() private view returns(bytes calldata) {
+            return msg.data;
+        }
+
+        function msgData() private view returns(bytes calldata) {
+            return msg.data;
+        }
+    }
+    "#;
+
+    let source_unit = solang_parser::parse(file_contents, 0).unwrap().0;
+
+    let qa_locations = private_func_leading_underscore(source_unit);
+    assert_eq!(qa_locations.len(), 2)
+}

--- a/src/analyzer/qa/private_vars_leading_underscore.rs
+++ b/src/analyzer/qa/private_vars_leading_underscore.rs
@@ -1,0 +1,63 @@
+use std::collections::HashSet;
+
+use solang_parser::pt::{self, FunctionTy, Loc};
+use solang_parser::{self, pt::SourceUnit};
+
+use crate::analyzer::ast::{self, Target};
+use crate::analyzer::utils::get_32_byte_storage_variables;
+
+pub fn private_vars_leading_underscore(source_unit: SourceUnit) -> HashSet<Loc> {
+    //Create a new hashset that stores the location of each qa target identified
+    let mut qa_locations: HashSet<Loc> = HashSet::new();
+
+    let storage_variables = get_32_byte_storage_variables(source_unit.clone(), true, false);
+
+    for (variable_name, variable_attribute) in storage_variables {
+        let (option_variable_attributes, loc) = variable_attribute;
+
+        if option_variable_attributes.is_some() {
+            let variable_attributes = option_variable_attributes.unwrap();
+
+            for attr in variable_attributes {
+                if let pt::VariableAttribute::Visibility(v) = attr {
+                    match v {
+                        pt::Visibility::Private(_) | pt::Visibility::Internal(_) => {
+                            if !variable_name.starts_with('_') {
+                                qa_locations.insert(loc);
+                            }
+                        }
+                        // Public variables
+                        _ => {
+                            if variable_name.starts_with('_') {
+                                qa_locations.insert(loc);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    //Return the identified qa locations
+    qa_locations
+}
+
+#[test]
+fn test_private_vars_leading_underscore() {
+    let file_contents = r#"
+    
+    contract Contract0 {
+        address public addr1;
+        address public _addr2;
+        address private _addr3;
+        address private addr4;
+        address internal _addr5;
+        address internal addr6;
+    }
+    "#;
+
+    let source_unit = solang_parser::parse(file_contents, 0).unwrap().0;
+
+    let qa_locations = private_vars_leading_underscore(source_unit);
+    assert_eq!(qa_locations.len(), 3)
+}

--- a/src/report/qa_report.rs
+++ b/src/report/qa_report.rs
@@ -5,7 +5,9 @@ use crate::analyzer::qa::QualityAssurance;
 use crate::analyzer::utils::LineNumber;
 use crate::report::report_sections::qa::overview;
 
-use super::report_sections::qa::constructor_order;
+use super::report_sections::qa::{
+    constructor_order, private_func_leading_underscore, private_vars_leading_underscore,
+};
 
 pub fn generate_qa_report(
     qa_items: HashMap<QualityAssurance, Vec<(String, BTreeSet<LineNumber>)>>,
@@ -48,5 +50,11 @@ pub fn generate_qa_report(
 pub fn get_qa_report_section(qa: QualityAssurance) -> String {
     match qa {
         QualityAssurance::ConstructorOrder => constructor_order::report_section_content(),
+        QualityAssurance::PrivateVarsLeadingUnderscore => {
+            private_vars_leading_underscore::report_section_content()
+        }
+        QualityAssurance::PrivateFuncLeadingUnderscore => {
+            private_func_leading_underscore::report_section_content()
+        }
     }
 }

--- a/src/report/report_sections/qa/mod.rs
+++ b/src/report/report_sections/qa/mod.rs
@@ -1,2 +1,4 @@
 pub mod constructor_order;
 pub mod overview;
+pub mod private_func_leading_underscore;
+pub mod private_vars_leading_underscore;

--- a/src/report/report_sections/qa/private_func_leading_underscore.rs
+++ b/src/report/report_sections/qa/private_func_leading_underscore.rs
@@ -1,0 +1,52 @@
+pub fn report_section_content() -> String {
+    String::from(
+        r##"
+## No use of underscore for internal and private function names | Don't use the underscore prefix for public and external function names
+
+Prefix `internal` and `private` function names with an underscore in order to follow `Style Guides Rules` (ref: https://github.com/protofire/solhint/blob/master/docs/rules/naming/private-vars-leading-underscore.md).
+In the other hand, public and external function names must not have an underscore prefix.
+
+```js
+// Bad
+contract Contract0 {
+   
+    function msgSender() private view returns (address) {
+        return msg.sender;
+    }
+
+    function msgData() internal view returns (bytes calldata) {
+        return msg.data;
+    }
+
+    function _currentTimestamp() public view returns(uint256) {
+        return block.timestamp;
+    }
+
+    function _currentBlockhash() external view returns(uint256) {
+        return block.blockhash;
+    }
+}
+
+// Good
+contract Contract1 {
+    
+    function _msgSender() private view returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view returns (bytes calldata) {
+        return msg.data;
+    }
+
+    function currentTimestamp() public view returns(uint256) {
+        return block.timestamp;
+    }
+
+    function currentBlockhash() external view returns(uint256) {
+        return block.blockhash;
+    }
+}
+```
+    "##,
+    )
+}

--- a/src/report/report_sections/qa/private_vars_leading_underscore.rs
+++ b/src/report/report_sections/qa/private_vars_leading_underscore.rs
@@ -1,0 +1,24 @@
+pub fn report_section_content() -> String {
+    String::from(
+        r##" 
+## No use of underscore for internal and private variable names | Don't use the underscore prefix for public variable names
+
+Prefix `internal` and `private` variable names with an underscore in order to follow `Style Guides Rules` (ref: https://github.com/protofire/solhint/blob/master/docs/rules/naming/private-vars-leading-underscore.md).
+In the other hand, public variable names must not have an underscore prefix.
+
+```js
+// Bad
+contract Contract0 {
+    address public _owner;
+    uint256 public _num1;
+}
+
+// Good
+contract Contract1 {
+    address public owner;
+    uint256 public num1;
+}
+```
+    "##,
+    )
+}


### PR DESCRIPTION
Related issue: #42 

In the [test case file](https://github.com/protofire/solhint/blob/57ce2662deb49ecf545e8e0f7788f5e32c9be859/test/rules/naming/private-vars-leading-underscore.js#L15), it mentions that public and externals names must not be prefixed with an underscore. Maybe this should be addressed in an separated analyzer?

In this PR both cases are taken account.